### PR TITLE
Integrate Meilisearch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,6 +1067,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "english-to-cron"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3d16f6dc9dc43a9a2fd5bce09b6cf8df250dcf77cffdaa66be21c527e2d05c"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4118,6 +4127,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "croner",
+ "english-to-cron",
  "num-derive",
  "num-traits",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -399,7 +399,7 @@ checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -446,9 +446,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
+checksum = "7d809780667f4410e7c41b07f52439b94d2bdf8528eeedc287fa38d3b7f95d82"
 
 [[package]]
 name = "bitflags"
@@ -525,9 +525,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.51"
+version = "1.2.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
+checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -562,10 +562,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.5.53"
+name = "chrono-tz"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -573,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -592,7 +602,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -672,6 +682,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
 
 [[package]]
+name = "croner"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa42bcd3d846ebf66e15bd528d1087f75d1c6c1c66ebff626178a106353c576"
+dependencies = [
+ "chrono",
+ "derive_builder",
+ "strum",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,7 +767,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -760,7 +781,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -771,7 +792,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -782,7 +803,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -848,6 +869,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,7 +918,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.112",
+ "syn 2.0.114",
  "unicode-xid",
 ]
 
@@ -909,7 +961,7 @@ dependencies = [
  "dsl_auto_type",
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -929,7 +981,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe2444076b48641147115697648dc743c2c00b61adade0f01ce67133c7babe8c"
 dependencies = [
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -961,7 +1013,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -981,7 +1033,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1058,9 +1110,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
+checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
 
 [[package]]
 name = "findshlibs"
@@ -1160,7 +1212,7 @@ checksum = "1458c6e22d36d61507034d5afecc64f105c1d39712b7ac6ec3b352c423f715cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1225,7 +1277,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1348,7 +1400,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1357,9 +1409,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1367,7 +1419,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1566,7 +1618,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.12",
+ "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -1588,12 +1640,12 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.8.1",
  "hyper-util",
- "rustls 0.23.35",
+ "rustls 0.23.36",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.4",
+ "webpki-roots 1.0.5",
 ]
 
 [[package]]
@@ -1800,9 +1852,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -1902,9 +1954,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.178"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libredox"
@@ -1999,7 +2051,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2022,7 +2074,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2068,7 +2120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36c791ecdf977c99f45f23280405d7723727470f6689a5e6dbf513ac547ae10d"
 dependencies = [
  "serde",
- "toml 0.9.10+spec-1.1.0",
+ "toml 0.9.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -2227,6 +2279,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2264,7 +2327,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2470,7 +2533,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2556,7 +2619,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2576,12 +2639,30 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.13.1",
  "serde",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -2698,14 +2779,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9695f8df41bb4f3d222c95a67532365f569318332d03d5f3f67f37b20e6ebdf0"
+checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
  "unicode-ident",
 ]
@@ -2718,7 +2799,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
  "version_check",
  "yansi",
 ]
@@ -2771,7 +2852,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.35",
+ "rustls 0.23.36",
  "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
@@ -2791,7 +2872,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.35",
+ "rustls 0.23.36",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.17",
@@ -2816,9 +2897,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
 ]
@@ -2966,7 +3047,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3055,7 +3136,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.12",
+ "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -3069,7 +3150,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.35",
+ "rustls 0.23.36",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3087,7 +3168,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.4",
+ "webpki-roots 1.0.5",
 ]
 
 [[package]]
@@ -3152,9 +3233,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.35"
+version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "once_cell",
  "ring",
@@ -3305,9 +3386,9 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "sentry"
-version = "0.46.0"
+version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9794f69ad475e76c057e326175d3088509649e3aed98473106b9fe94ba59424"
+checksum = "2f925d575b468e88b079faf590a8dd0c9c99e2ec29e9bab663ceb8b45056312f"
 dependencies = [
  "httpdate",
  "native-tls",
@@ -3328,9 +3409,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-actix"
-version = "0.46.0"
+version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0fee202934063ace4f1d1d063113b8982293762628e563a2d2fba08fb20b110"
+checksum = "18bac0f6b8621fa0f85e298901e51161205788322e1a995e3764329020368058"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -3341,9 +3422,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-anyhow"
-version = "0.46.0"
+version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1832cd051f3198af8ebc5222da5fd213e49976d758b7defa7accbff3aed1909"
+checksum = "c8e45993dc8981e7fb5d9b7f701f65ca5c9fb0390263e47f612f30bea3d35fac"
 dependencies = [
  "anyhow",
  "sentry-backtrace",
@@ -3352,9 +3433,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.46.0"
+version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e81137ad53b8592bd0935459ad74c0376053c40084aa170451e74eeea8dbc6c3"
+checksum = "6cb1ef7534f583af20452b1b1bf610a60ed9c8dd2d8485e7bd064efc556a78fb"
 dependencies = [
  "backtrace",
  "regex",
@@ -3363,9 +3444,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.46.0"
+version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfb403c66cc2651a01b9bacda2e7c22cd51f7e8f56f206aa4310147eb3259282"
+checksum = "ebd6be899d9938390b6d1ec71e2f53bd9e57b6a9d8b1d5b049e5c364e7da9078"
 dependencies = [
  "hostname",
  "libc",
@@ -3377,9 +3458,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.46.0"
+version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc409727ae90765ca8ea76fe6c949d6f159a11d02e130b357fa652ee9efcada"
+checksum = "26ab054c34b87f96c3e4701bea1888317cde30cc7e4a6136d2c48454ab96661c"
 dependencies = [
  "rand 0.9.2",
  "sentry-types",
@@ -3390,9 +3471,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.46.0"
+version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06a2778a222fd90ebb01027c341a72f8e24b0c604c6126504a4fe34e5500e646"
+checksum = "5637ec550dc6f8c49a711537950722d3fc4baa6fd433c371912104eaff31e2a5"
 dependencies = [
  "findshlibs",
  "sentry-core",
@@ -3400,9 +3481,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-log"
-version = "0.46.0"
+version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a63c02619733e917643fa91ec6744a18a1e48236cd876ce908a4c2b04f17bdf"
+checksum = "0f95c213ed8ffd52952174a956a2c32b012ecea8e778a3b1cc24d2d8603306f5"
 dependencies = [
  "bitflags 2.10.0",
  "log",
@@ -3411,9 +3492,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.46.0"
+version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df79f4e1e72b2a8b75a0ebf49e78709ceb9b3f0b451f13adc92a0361b0aaabe"
+checksum = "3f02c7162f7b69b8de872b439d4696dc1d65f80b13ddd3c3831723def4756b63"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -3421,9 +3502,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-tower"
-version = "0.46.0"
+version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eec9885bceb8ba374858d015bb6fa39dbb341d94ca088bc8f13bee2e64e2c68"
+checksum = "01876ce0b0bfa801ea596f1684fca570cdf2ad191267253cdcc04251433c3bd7"
 dependencies = [
  "sentry-core",
  "tower-layer",
@@ -3432,9 +3513,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.46.0"
+version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2046f527fd4b75e0b6ab3bd656c67dce42072f828dc4d03c206d15dca74a93"
+checksum = "e1dd47df349a80025819f3d25c3d2f751df705d49c65a4cdc0f130f700972a48"
 dependencies = [
  "bitflags 2.10.0",
  "sentry-backtrace",
@@ -3445,9 +3526,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.46.0"
+version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7b9b4e4c03a4d3643c18c78b8aa91d2cbee5da047d2fa0ca4bb29bc67e6c55c"
+checksum = "eecbd63e9d15a26a40675ed180d376fcb434635d2e33de1c24003f61e3e2230d"
 dependencies = [
  "debugid",
  "hex",
@@ -3478,7 +3559,7 @@ checksum = "92d48532bc0781ac622a5fea0f16502d3b4f1af0fcebe56d618120969f35d315"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3507,7 +3588,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3517,7 +3598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2f2d7ff8a2140333718bb329f5c40fc5f0865b84c426183ce14c97d2ab8154f"
 dependencies = [
  "form_urlencoded",
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "itoa",
  "ryu",
  "serde_core",
@@ -3525,9 +3606,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.148"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3084b546a1dd6289475996f182a22aba973866ea8e8b02c51d9f46b1336a22da"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
@@ -3555,7 +3636,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3598,7 +3679,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "schemars 0.9.0",
  "schemars 1.2.0",
  "serde_core",
@@ -3616,7 +3697,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3783,7 +3864,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3794,7 +3875,28 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3816,9 +3918,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.112"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21f182278bf2d2bcb3c88b1b08a37df029d71ce3d3ae26168e3c653b213b99d4"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3848,7 +3950,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3911,7 +4013,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3922,7 +4024,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3992,9 +4094,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "libc",
@@ -4008,6 +4110,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-cron-scheduler"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f50e41f200fd8ed426489bd356910ede4f053e30cebfbd59ef0f856f0d7432a"
+dependencies = [
+ "chrono",
+ "chrono-tz",
+ "croner",
+ "num-derive",
+ "num-traits",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4015,7 +4133,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4043,7 +4161,7 @@ dependencies = [
  "log",
  "parking_lot",
  "percent-encoding",
- "phf",
+ "phf 0.13.1",
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
@@ -4060,15 +4178,15 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.35",
+ "rustls 0.23.36",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4077,9 +4195,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4102,11 +4220,11 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.10+spec-1.1.0"
+version = "0.9.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0825052159284a1a8b4d6c0c86cbc801f2da5afd2b225fa548c72f2e74002f48"
+checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
 dependencies = [
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "serde_core",
  "serde_spanned 1.0.4",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -4139,7 +4257,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -4153,7 +4271,7 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
@@ -4268,7 +4386,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4342,9 +4460,9 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "2.8.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"
@@ -4428,14 +4546,15 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -4468,7 +4587,7 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
 dependencies = [
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -4496,7 +4615,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4550,7 +4669,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4646,7 +4765,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
@@ -4704,7 +4823,8 @@ dependencies = [
  "steam-rs",
  "time",
  "tokio",
- "toml 0.9.10+spec-1.1.0",
+ "tokio-cron-scheduler",
+ "toml 0.9.11+spec-1.1.0",
  "tower",
  "tower-http",
  "tracing",
@@ -4739,9 +4859,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3e3b5f5e80bc89f30ce8d0343bf4e5f12341c51f3e26cbeecbc7c85443e85b"
+checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4754,9 +4874,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
+checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4815,7 +4935,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4826,7 +4946,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5142,28 +5262,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.31"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.31"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5183,7 +5303,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -5223,11 +5343,11 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.112",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.6"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac060176f7020d62c3bcc1cdbcec619d54f48b07ad1963a3f80ce7a0c17755f"
+checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,6 +290,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a88aab2464f1f25453baa7a07c84c5b7684e274054ba06817f382357f77a288"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45afffdee1e7c9126814751f88dddc747f41d91da16c9551a0f1e8a11e788a1"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,7 +414,7 @@ dependencies = [
  "mime",
  "quick-xml 0.37.5",
  "serde",
- "thiserror",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -507,6 +530,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -577,10 +602,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "convert_case"
@@ -819,7 +862,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -942,6 +985,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,6 +1001,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -1110,6 +1162,12 @@ dependencies = [
  "quote",
  "syn 2.0.112",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1298,6 +1356,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
+ "indexmap 2.12.1",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1465,7 +1542,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -1489,6 +1566,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2 0.4.12",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -1761,10 +1839,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "iso8601"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
+dependencies = [
+ "nom 8.0.0",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1774,6 +1871,21 @@ checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "10.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c76e1c7d7df3e34443b3621b459b066a7b79644f059fc8b2db7070c825fd417e"
+dependencies = [
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "getrandom 0.2.16",
+ "js-sys",
+ "serde",
+ "serde_json",
+ "signature",
 ]
 
 [[package]]
@@ -1901,6 +2013,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "meilisearch-index-setting-macro"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0795d177129fed792fc789cf07d4647bb9e3939409fbe01764805c060afcd0e"
+dependencies = [
+ "convert_case 0.8.0",
+ "proc-macro2",
+ "quote",
+ "structmeta",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "meilisearch-sdk"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a20b5a4215a39c66854d14cbba97f615e84c49925d68629c05c42a5a85dac1"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "iso8601",
+ "jsonwebtoken",
+ "log",
+ "meilisearch-index-setting-macro",
+ "pin-project-lite",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "time",
+ "tokio",
+ "uuid",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "yaup",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1997,7 +2152,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
 ]
@@ -2039,6 +2194,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2609,7 +2773,7 @@ dependencies = [
  "rustc-hash",
  "rustls 0.23.35",
  "socket2 0.6.1",
- "thiserror",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "web-time",
@@ -2630,7 +2794,7 @@ dependencies = [
  "rustls 0.23.35",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.17",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2764,7 +2928,7 @@ dependencies = [
  "cookie-factory",
  "crc16",
  "log",
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -2851,7 +3015,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
@@ -2891,6 +3055,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2 0.4.12",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -2913,12 +3078,14 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.4",
 ]
@@ -2933,7 +3100,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.16",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -3023,7 +3190,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3034,7 +3201,7 @@ checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3104,7 +3271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3287,7 +3454,7 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.17",
  "time",
  "url",
  "uuid",
@@ -3500,6 +3667,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3599,6 +3775,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3688,11 +3887,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.17",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -4036,7 +4255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
 dependencies = [
  "crossbeam-channel",
- "thiserror",
+ "thiserror 2.0.17",
  "time",
  "tracing-subscriber",
 ]
@@ -4168,6 +4387,12 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -4292,6 +4517,7 @@ version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
+ "getrandom 0.3.4",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -4434,6 +4660,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wavebreaker"
 version = "0.1.0"
 dependencies = [
@@ -4448,6 +4687,7 @@ dependencies = [
  "figment",
  "fred",
  "futures",
+ "meilisearch-sdk",
  "musicbrainz_rs",
  "num_enum",
  "quick-xml 0.38.4",
@@ -4871,6 +5111,17 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yaup"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0144f1a16a199846cb21024da74edd930b43443463292f536b7110b4855b5c6"
+dependencies = [
+ "form_urlencoded",
+ "serde",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,4 @@ sentry = { version = "0.46.0", features = ["tracing", "anyhow", "tower", "logs"]
 tower = "0.5.2"
 futures = "0.3.31"
 meilisearch-sdk = "0.32"
+tokio-cron-scheduler = "0.15.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,4 @@ rand = "0.9.2"
 sentry = { version = "0.46.0", features = ["tracing", "anyhow", "tower", "logs"] }
 tower = "0.5.2"
 futures = "0.3.31"
+meilisearch-sdk = "0.32"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,4 +49,4 @@ sentry = { version = "0.46.0", features = ["tracing", "anyhow", "tower", "logs"]
 tower = "0.5.2"
 futures = "0.3.31"
 meilisearch-sdk = "0.32"
-tokio-cron-scheduler = "0.15.1"
+tokio-cron-scheduler = { version = "0.15.1", features = ["english"] }

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ steam_return_path = "/api/auth/return"
 # if you plan on using Sentry, the DSN is required
 # anything else not specified is set to the default
 sentry_dsn = "https://somethingsomething@your.sentry.or.glitchtip/whatever"
-sentry_logs = true,
-sentry_traces_sample_rate = 1.0,
-sentry_send_pii = true,
+sentry_logs = true
+sentry_traces_sample_rate = 1.0
+sentry_send_pii = true
 ```
 
 Radio song list example (``WavebreakerRadio.toml``):

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ redis = "redis://valkey"
 # Meilisearch is optional, Wavebreaker works without it but it's needed for search
 meilisearch_url = "http://localhost:7700"
 meilisearch_key = "DANCE_DELIGHTFUL_IT_FEELS_SO_RIGHT"
+# How often to sync songs with Meilisearch.
+# written in cron's schedule format
+song_sync_schedule = "0 */10 * * * *"
+# Same but with user sync
+# It also supports plain english, using https://crates.io/crates/english-to-cron
+player_sync_schedule = "every 10 minutes"
 
 [radio]
 cgr_location = "./radio"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Config example (``Wavebreaker.toml``), usable with the example `docker-compose.y
 address = "0.0.0.0:1337"
 database = "postgres://postgres:wvbr_testpw@db"
 redis = "redis://valkey"
+# Meilisearch is optional, Wavebreaker works without it but it's needed for search
+meilisearch_url = "http://localhost:7700"
+meilisearch_key = "DANCE_DELIGHTFUL_IT_FEELS_SO_RIGHT"
 
 [radio]
 cgr_location = "./radio"

--- a/migrations/2026-01-04-114817-0000_song_info_update_time/down.sql
+++ b/migrations/2026-01-04-114817-0000_song_info_update_time/down.sql
@@ -1,0 +1,6 @@
+-- This file should undo anything in `up.sql`
+DROP TRIGGER set_updated_at ON songs;
+DROP TRIGGER set_updated_at ON extra_song_info;
+
+ALTER TABLE songs DROP COLUMN updated_at;
+ALTER TABLE extra_song_info DROP COLUMN updated_at;

--- a/migrations/2026-01-04-114817-0000_song_info_update_time/up.sql
+++ b/migrations/2026-01-04-114817-0000_song_info_update_time/up.sql
@@ -1,0 +1,6 @@
+-- Your SQL goes here
+ALTER TABLE songs ADD updated_at TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE extra_song_info ADD updated_at TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+SELECT diesel_manage_updated_at('songs');
+SELECT diesel_manage_updated_at('extra_song_info');

--- a/migrations/2026-01-20-193731-0000_user_updated_at/down.sql
+++ b/migrations/2026-01-20-193731-0000_user_updated_at/down.sql
@@ -1,0 +1,4 @@
+-- This file should undo anything in `up.sql`
+DROP TRIGGER set_updated_at ON players;
+
+ALTER TABLE players DROP COLUMN updated_at;

--- a/migrations/2026-01-20-193731-0000_user_updated_at/up.sql
+++ b/migrations/2026-01-20-193731-0000_user_updated_at/up.sql
@@ -1,0 +1,4 @@
+-- Your SQL goes here
+ALTER TABLE players ADD updated_at TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+SELECT diesel_manage_updated_at('players');

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -73,6 +73,7 @@ struct ServerStats {
     user_count: i64,
     song_count: i64,
     score_count: i64,
+    search_supported: bool,
 }
 
 /// Get server stats
@@ -98,5 +99,6 @@ async fn stats(State(state): State<AppState>) -> Result<Json<ServerStats>, Route
         user_count,
         song_count,
         score_count,
+        search_supported: state.meilisearch.is_some(),
     }))
 }

--- a/src/api/songs.rs
+++ b/src/api/songs.rs
@@ -49,7 +49,7 @@ struct SongResponse {
     #[serde(flatten)]
     song: Song,
     #[serde(skip_serializing_if = "Option::is_none")]
-    extra_info: Option<ExtraSongInfo>,
+    extra_song_info: Option<ExtraSongInfo>,
 }
 
 #[derive(Serialize, ToSchema)]
@@ -99,16 +99,19 @@ async fn get_song(
         .optional()?
         .ok_or_else(RouteError::new_not_found)?;
     if query.with_extra_info {
-        let extra_info: Option<ExtraSongInfo> = ExtraSongInfo::belonging_to(&song)
+        let extra_song_info: Option<ExtraSongInfo> = ExtraSongInfo::belonging_to(&song)
             .first(&mut conn)
             .await
             .optional()?;
-        return Ok(Json(SongResponse { song, extra_info }));
+        return Ok(Json(SongResponse {
+            song,
+            extra_song_info,
+        }));
     }
 
     Ok(Json(SongResponse {
         song,
-        extra_info: None,
+        extra_song_info: None,
     }))
 }
 
@@ -263,8 +266,11 @@ async fn get_top_songs(
 
         let songs: Vec<TopSongResponse> = songs_with_extra
             .into_iter()
-            .map(|(song, times_played, extra_info)| TopSongResponse {
-                song_data: SongResponse { song, extra_info },
+            .map(|(song, times_played, extra_song_info)| TopSongResponse {
+                song_data: SongResponse {
+                    song,
+                    extra_song_info,
+                },
                 times_played,
             })
             .collect();
@@ -289,7 +295,7 @@ async fn get_top_songs(
             .map(|(song, times_played)| TopSongResponse {
                 song_data: SongResponse {
                     song,
-                    extra_info: None,
+                    extra_song_info: None,
                 },
                 times_played,
             })

--- a/src/api/songs.rs
+++ b/src/api/songs.rs
@@ -145,7 +145,8 @@ async fn delete_song(
         .ok_or_else(RouteError::new_not_found)?;
 
     if song.user_can_delete(&session.player, &mut conn).await? {
-        song.delete(&mut conn, &state.redis).await?;
+        song.delete(&mut conn, &state.redis, state.meilisearch.as_deref())
+            .await?;
 
         Ok(())
     } else {

--- a/src/api/songs.rs
+++ b/src/api/songs.rs
@@ -180,6 +180,7 @@ allow_columns_to_appear_in_same_group_by_clause!(
     schema::songs::artist,
     schema::songs::created_at,
     schema::songs::modifiers,
+    schema::songs::updated_at,
     schema::extra_song_info::id,
     schema::extra_song_info::song_id,
     schema::extra_song_info::cover_url,
@@ -191,6 +192,7 @@ allow_columns_to_appear_in_same_group_by_clause!(
     schema::extra_song_info::mistag_lock,
     schema::extra_song_info::aliases_artist,
     schema::extra_song_info::aliases_title,
+    schema::extra_song_info::updated_at,
 );
 
 /// Get global most played songs

--- a/src/api/songs.rs
+++ b/src/api/songs.rs
@@ -1,8 +1,9 @@
 use axum::{
     extract::{Path, Query, State},
-    http::StatusCode,
     Json,
 };
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use serde::{Deserialize, Serialize};
 use serde_inline_default::serde_inline_default;
 use tracing::instrument;
@@ -40,16 +41,15 @@ pub fn routes() -> OpenApiRouter<AppState> {
         .routes(routes!(update_song_extra_info))
         .routes(routes!(update_song_extra_info_mbid))
         .routes(routes!(get_song_permissions))
-        .routes(routes!(search_songs))
 }
 
-#[derive(Deserialize, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 struct SongResponse {
     #[serde(flatten)]
     song: Song,
     #[serde(skip_serializing_if = "Option::is_none")]
-    extra_song_info: Option<ExtraSongInfo>,
+    extra_info: Option<ExtraSongInfo>,
 }
 
 #[derive(Serialize, ToSchema)]
@@ -87,8 +87,6 @@ async fn get_song(
     query: Query<GetSongParams>,
 ) -> Result<Json<SongResponse>, RouteError> {
     use crate::schema::songs;
-    use diesel::prelude::*;
-    use diesel_async::RunQueryDsl;
 
     let mut conn = state.db.get().await?;
 
@@ -99,19 +97,16 @@ async fn get_song(
         .optional()?
         .ok_or_else(RouteError::new_not_found)?;
     if query.with_extra_info {
-        let extra_song_info: Option<ExtraSongInfo> = ExtraSongInfo::belonging_to(&song)
+        let extra_info: Option<ExtraSongInfo> = ExtraSongInfo::belonging_to(&song)
             .first(&mut conn)
             .await
             .optional()?;
-        return Ok(Json(SongResponse {
-            song,
-            extra_song_info,
-        }));
+        return Ok(Json(SongResponse { song, extra_info }));
     }
 
     Ok(Json(SongResponse {
         song,
-        extra_song_info: None,
+        extra_info: None,
     }))
 }
 
@@ -139,8 +134,6 @@ async fn delete_song(
     session: Session,
 ) -> Result<(), RouteError> {
     use crate::schema::songs;
-    use diesel::prelude::*;
-    use diesel_async::RunQueryDsl;
 
     let mut conn = state.db.get().await?;
 
@@ -182,7 +175,7 @@ struct TopSongResponse {
     times_played: i64,
 }
 
-diesel::allow_columns_to_appear_in_same_group_by_clause!(
+allow_columns_to_appear_in_same_group_by_clause!(
     schema::songs::id,
     schema::songs::title,
     schema::songs::artist,
@@ -223,9 +216,7 @@ async fn get_top_songs(
     State(state): State<AppState>,
     ValidatedQuery(query): ValidatedQuery<GetTopSongParams>,
 ) -> Result<Json<Vec<TopSongResponse>>, RouteError> {
-    use diesel::prelude::*;
     use diesel::{dsl::sql, sql_types::BigInt};
-    use diesel_async::RunQueryDsl;
 
     use crate::schema::{extra_song_info, scores, songs};
 
@@ -266,11 +257,8 @@ async fn get_top_songs(
 
         let songs: Vec<TopSongResponse> = songs_with_extra
             .into_iter()
-            .map(|(song, times_played, extra_song_info)| TopSongResponse {
-                song_data: SongResponse {
-                    song,
-                    extra_song_info,
-                },
+            .map(|(song, times_played, extra_info)| TopSongResponse {
+                song_data: SongResponse { song, extra_info },
                 times_played,
             })
             .collect();
@@ -295,7 +283,7 @@ async fn get_top_songs(
             .map(|(song, times_played)| TopSongResponse {
                 song_data: SongResponse {
                     song,
-                    extra_song_info: None,
+                    extra_info: None,
                 },
                 times_played,
             })
@@ -357,8 +345,6 @@ async fn get_song_scores(
     ValidatedQuery(query): ValidatedQuery<GetSongScoresParams>,
 ) -> Result<Json<Vec<ScoreResponse>>, RouteError> {
     use crate::schema::{players, scores, songs};
-    use diesel::prelude::*;
-    use diesel_async::RunQueryDsl;
 
     let mut conn = state.db.get().await?;
 
@@ -442,8 +428,6 @@ async fn get_radio_songs(
     query: Query<GetSongParams>,
 ) -> Result<Json<Vec<RadioSongResponse>>, RouteError> {
     use crate::schema::{extra_song_info, songs};
-    use diesel::prelude::*;
-    use diesel_async::RunQueryDsl;
 
     let mut conn = state.db.get().await?;
 
@@ -541,8 +525,6 @@ async fn get_song_shouts(
     ValidatedQuery(query): ValidatedQuery<GetSongShoutsParams>,
 ) -> Result<Json<SongShoutsResponse>, RouteError> {
     use crate::schema::{players, shouts, songs};
-    use diesel::prelude::*;
-    use diesel_async::RunQueryDsl;
 
     let mut conn = state.db.get().await?;
 
@@ -604,8 +586,6 @@ async fn update_song_extra_info(
     Json(extra_info): Json<NewExtraSongInfo>,
 ) -> Result<(), RouteError> {
     use diesel::insert_into;
-    use diesel::prelude::*;
-    use diesel_async::RunQueryDsl;
 
     use crate::schema::{extra_song_info, songs};
 
@@ -675,8 +655,7 @@ async fn update_song_extra_info_mbid(
     session: Session,
     Json(payload): Json<MbidRefreshBody>,
 ) -> Result<(), RouteError> {
-    use diesel::prelude::*;
-    use diesel_async::RunQueryDsl;
+    use diesel::insert_into;
 
     use crate::schema::{extra_song_info, songs};
 
@@ -697,7 +676,7 @@ async fn update_song_extra_info_mbid(
         )
         .await?;
 
-        diesel::insert_into(extra_song_info::table)
+        insert_into(extra_song_info::table)
             .values(&mb_info)
             .on_conflict(extra_song_info::song_id)
             .do_update()
@@ -731,8 +710,6 @@ async fn get_song_permissions(
     session: Session,
 ) -> Result<Json<SongPermissions>, RouteError> {
     use crate::schema::songs;
-    use diesel::prelude::*;
-    use diesel_async::RunQueryDsl;
 
     let mut conn = state.db.get().await?;
 
@@ -747,43 +724,4 @@ async fn get_song_permissions(
         can_delete: song.user_can_delete(&session.player, &mut conn).await?,
         can_edit: song.user_can_edit(&session.player, &mut conn).await?,
     }))
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct SongSearchParams {
-    q: String,
-}
-
-/// Search for songs
-#[utoipa::path(
-    method(get),
-    path = "/search",
-    params(
-        ("q" = String, Query, description = "Search query")
-    ),
-    responses(
-        // ...maybe somehow specify meilisearch response type?
-        (status = OK, description = "Success", content_type = "application/json"),
-        (status = SERVICE_UNAVAILABLE, description = "Meilisearch is unavailable", body = SimpleRouteErrorOutput),
-        (status = INTERNAL_SERVER_ERROR, description = "Miscellaneous error", body = SimpleRouteErrorOutput)
-    )
-)]
-#[instrument(skip(state), err(Debug))]
-async fn search_songs(
-    State(state): State<AppState>,
-    query: Query<SongSearchParams>,
-) -> Result<Json<meilisearch_sdk::search::SearchResults<SongResponse>>, RouteError> {
-    if let Some(meilisearch) = state.meilisearch {
-        let results = meilisearch
-            .index("songs")
-            .search()
-            .with_query(&query.q)
-            .execute::<SongResponse>()
-            .await?;
-
-        Ok(Json(results))
-    } else {
-        Err(RouteError::from_status(StatusCode::SERVICE_UNAVAILABLE))
-    }
 }

--- a/src/api/songs.rs
+++ b/src/api/songs.rs
@@ -759,7 +759,7 @@ struct SongSearchParams {
     responses(
         // ...maybe somehow specify meilisearch response type?
         (status = OK, description = "Success", content_type = "application/json"),
-        (status = SERVICE_UNAVAILABLE, description = "Search is unavailable", body = SimpleRouteErrorOutput),
+        (status = SERVICE_UNAVAILABLE, description = "Meilisearch is unavailable", body = SimpleRouteErrorOutput),
         (status = INTERNAL_SERVER_ERROR, description = "Miscellaneous error", body = SimpleRouteErrorOutput)
     )
 )]

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,8 @@ struct Main {
     redis: String,
     meilisearch_url: Option<String>,
     meilisearch_key: Option<String>,
+    song_sync_schedule: Option<String>,
+    player_sync_schedule: Option<String>,
 }
 
 #[derive(Deserialize, Clone)]
@@ -277,7 +279,7 @@ fn main() -> anyhow::Result<()> {
                 let db = state.db.clone();
                 // run song sync every 10 minutes
                 sched
-                    .add(Job::new_async("0 */10 * * * *", move |_uuid, mut _l| {
+                    .add(Job::new_async(wavebreaker_config.main.song_sync_schedule.unwrap_or("0 */10 * * * *".to_owned()), move |_uuid, mut _l| {
                         let client = client.clone();
                         let redis = redis.clone();
                         let db = db.clone();
@@ -296,7 +298,7 @@ fn main() -> anyhow::Result<()> {
                 let db2 = state.db.clone();
                 // run player sync every 10 minutes
                 sched
-                    .add(Job::new_async("0 */10 * * * *", move |_uuid, mut _l| {
+                    .add(Job::new_async(wavebreaker_config.main.player_sync_schedule.unwrap_or("0 */10 * * * *".to_owned()), move |_uuid, mut _l| {
                         let client = client2.clone();
                         let redis = redis2.clone();
                         let db = db2.clone();

--- a/src/models/extra_song_info.rs
+++ b/src/models/extra_song_info.rs
@@ -17,7 +17,6 @@ use crate::schema::extra_song_info;
     Eq,
     Debug,
     Serialize,
-    Default,
     AsChangeset,
     ToSchema,
 )]
@@ -41,6 +40,30 @@ pub struct ExtraSongInfo {
     pub aliases_artist: Option<Vec<Option<String>>>,
     /// Alternative title tags that can be matched to this song
     pub aliases_title: Option<Vec<Option<String>>>,
+    #[serde(serialize_with = "time::serde::iso8601::serialize")]
+    #[serde(deserialize_with = "time::serde::iso8601::deserialize")]
+    pub updated_at: time::OffsetDateTime,
+}
+
+impl Default for ExtraSongInfo {
+    fn default() -> Self {
+        // i'm going to be real with you chief
+        // i am not pulling in a crate with a macro just to make this look better
+        Self {
+            id: Default::default(),
+            song_id: Default::default(),
+            cover_url: Default::default(),
+            cover_url_small: Default::default(),
+            mbid: Default::default(),
+            musicbrainz_title: Default::default(),
+            musicbrainz_artist: Default::default(),
+            musicbrainz_length: Default::default(),
+            mistag_lock: Default::default(),
+            aliases_artist: Default::default(),
+            aliases_title: Default::default(),
+            updated_at: time::OffsetDateTime::now_utc(),
+        }
+    }
 }
 
 /// Used for inserting additional metadata from [MusicBrainz](https://musicbrainz.org).

--- a/src/models/extra_song_info.rs
+++ b/src/models/extra_song_info.rs
@@ -9,6 +9,7 @@ use crate::schema::extra_song_info;
 /// Used for storing additional metadata from [MusicBrainz](https://musicbrainz.org).
 /// This lets us display fancy stuff™ on the song page.
 #[derive(
+    Clone,
     Queryable,
     Selectable,
     Identifiable,
@@ -17,6 +18,7 @@ use crate::schema::extra_song_info;
     Eq,
     Debug,
     Serialize,
+    Deserialize,
     AsChangeset,
     ToSchema,
 )]

--- a/src/models/players.rs
+++ b/src/models/players.rs
@@ -264,24 +264,6 @@ impl Player {
             .await
     }
 
-    /// Retrieves the rivals of a player.
-    pub async fn delete(
-        &self,
-        conn: &mut AsyncPgConnection,
-        redis_conn: &RedisPool,
-        meili: &Option<MeiliClient>,
-    ) -> anyhow::Result<()> {
-        use crate::schema::players::dsl::*;
-
-        diesel::delete(players.find(self.id)).execute(conn).await?;
-        let _: () = redis_conn.zrem("leaderboard", self.id).await?;
-        if let Some(meili) = meili {
-            meili.index("players").delete_document(self.id).await?;
-        }
-
-        Ok(())
-    }
-
     /// Retrieves the challengers of a player.
     pub async fn get_challengers(&self, conn: &mut AsyncPgConnection) -> QueryResult<Vec<Self>> {
         use crate::schema::{players::dsl::*, rivalries::dsl::*};

--- a/src/models/players.rs
+++ b/src/models/players.rs
@@ -137,7 +137,7 @@ impl Player {
         &self,
         conn: &mut AsyncPgConnection,
         redis_conn: &RedisPool,
-        meili: &Option<MeiliClient>,
+        meili: Option<&MeiliClient>,
     ) -> anyhow::Result<()> {
         use crate::schema::players::dsl::*;
 

--- a/src/models/players.rs
+++ b/src/models/players.rs
@@ -119,6 +119,9 @@ pub struct Player {
     #[serde(deserialize_with = "time::serde::iso8601::deserialize")]
     pub joined_at: time::OffsetDateTime,
     pub avatar_url: String,
+    #[serde(serialize_with = "time::serde::iso8601::serialize")]
+    #[serde(deserialize_with = "time::serde::iso8601::deserialize")]
+    pub updated_at: time::OffsetDateTime,
 }
 
 // Types for use with functions that return reusable query fragments

--- a/src/models/songs.rs
+++ b/src/models/songs.rs
@@ -2,7 +2,7 @@ use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl, SaveChangesDsl};
 use fred::clients::Pool as RedisPool;
 use musicbrainz_rs::client::MusicBrainzClient;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tracing::debug;
 use utoipa::ToSchema;
 
@@ -16,7 +16,15 @@ use crate::{
 };
 
 #[derive(
-    Clone, Identifiable, Selectable, Queryable, Debug, Serialize, ToSchema, QueryableByName,
+    Clone,
+    Identifiable,
+    Selectable,
+    Queryable,
+    Debug,
+    Deserialize,
+    Serialize,
+    ToSchema,
+    QueryableByName,
 )]
 #[diesel(table_name = songs, check_for_backend(diesel::pg::Pg))]
 #[diesel(primary_key(id))]
@@ -27,6 +35,7 @@ pub struct Song {
     pub title: String,
     pub artist: String,
     #[serde(serialize_with = "time::serde::iso8601::serialize")]
+    #[serde(deserialize_with = "time::serde::iso8601::deserialize")]
     pub created_at: time::OffsetDateTime,
     pub modifiers: Option<Vec<Option<String>>>,
     #[serde(serialize_with = "time::serde::iso8601::serialize")]

--- a/src/models/songs.rs
+++ b/src/models/songs.rs
@@ -29,6 +29,9 @@ pub struct Song {
     #[serde(serialize_with = "time::serde::iso8601::serialize")]
     pub created_at: time::OffsetDateTime,
     pub modifiers: Option<Vec<Option<String>>>,
+    #[serde(serialize_with = "time::serde::iso8601::serialize")]
+    #[serde(deserialize_with = "time::serde::iso8601::deserialize")]
+    pub updated_at: time::OffsetDateTime,
 }
 
 impl Song {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -13,6 +13,7 @@ diesel::table! {
         mistag_lock -> Bool,
         aliases_artist -> Nullable<Array<Nullable<Text>>>,
         aliases_title -> Nullable<Array<Nullable<Text>>>,
+        updated_at -> Timestamptz,
     }
 }
 
@@ -77,6 +78,7 @@ diesel::table! {
         artist -> Text,
         created_at -> Timestamptz,
         modifiers -> Nullable<Array<Nullable<Text>>>,
+        updated_at -> Timestamptz,
     }
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -28,6 +28,7 @@ diesel::table! {
         account_type -> Int2,
         joined_at -> Timestamptz,
         avatar_url -> Text,
+        updated_at -> Timestamptz,
     }
 }
 

--- a/src/util/meilisearch.rs
+++ b/src/util/meilisearch.rs
@@ -15,16 +15,16 @@ use crate::schema::songs;
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct MeiliSong {
+pub struct MeiliSong {
     #[serde(flatten)]
-    song: Song,
+    pub song: Song,
     #[serde(skip_serializing_if = "Option::is_none")]
-    extra_song_info: Option<ExtraSongInfo>,
+    pub extra_song_info: Option<ExtraSongInfo>,
 }
 
 #[tracing::instrument(skip_all)]
 pub async fn sync_songs(
-    meili: &Option<MeiliClient>,
+    meili: &MeiliClient,
     redis: &RedisPool,
     db: &PostgresPool<diesel_async::AsyncPgConnection>,
 ) -> anyhow::Result<()> {
@@ -69,8 +69,6 @@ pub async fn sync_songs(
         .collect();
 
     meili
-        .as_ref()
-        .unwrap()
         .index("songs")
         .add_documents(&songs_to_sync, Some("id"))
         .await?;

--- a/src/util/meilisearch.rs
+++ b/src/util/meilisearch.rs
@@ -1,0 +1,1 @@
+use meilisearch_sdk::client::*;

--- a/src/util/meilisearch.rs
+++ b/src/util/meilisearch.rs
@@ -18,7 +18,6 @@ use crate::schema::songs;
 pub struct MeiliSong {
     #[serde(flatten)]
     pub song: Song,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub extra_song_info: Option<ExtraSongInfo>,
 }
 

--- a/src/util/meilisearch.rs
+++ b/src/util/meilisearch.rs
@@ -1,1 +1,7 @@
 use meilisearch_sdk::client::*;
+use tracing::info;
+
+pub fn sync_songs(meili: &Option<Client>) -> () {
+    info!("Syncing songs to Meilisearch");
+    todo!();
+}

--- a/src/util/meilisearch.rs
+++ b/src/util/meilisearch.rs
@@ -1,7 +1,89 @@
-use meilisearch_sdk::client::*;
+use diesel::prelude::*;
+use diesel_async::pooled_connection::deadpool::Pool as PostgresPool;
+use diesel_async::RunQueryDsl;
+use fred::clients::Pool as RedisPool;
+use fred::prelude::*;
+use meilisearch_sdk::client::Client as MeiliClient;
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
 use tracing::info;
 
-pub fn sync_songs(meili: &Option<Client>) -> () {
+use crate::models::extra_song_info::ExtraSongInfo;
+use crate::models::songs::Song;
+use crate::schema::extra_song_info;
+use crate::schema::songs;
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MeiliSong {
+    #[serde(flatten)]
+    song: Song,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    extra_song_info: Option<ExtraSongInfo>,
+}
+
+#[tracing::instrument(skip_all)]
+pub async fn sync_songs(
+    meili: &Option<MeiliClient>,
+    redis: &RedisPool,
+    db: &PostgresPool<diesel_async::AsyncPgConnection>,
+) -> anyhow::Result<()> {
     info!("Syncing songs to Meilisearch");
-    todo!();
+
+    let mut conn = db.get().await?;
+
+    let _: () = redis
+        .set(
+            "last_meilisearch_sync",
+            OffsetDateTime::now_utc().unix_timestamp(),
+            None,
+            Some(SetOptions::NX),
+            false,
+        )
+        .await?;
+
+    let last_sync: OffsetDateTime = redis.get("last_meilisearch_sync").await.map(|i| {
+        OffsetDateTime::from_unix_timestamp(i)
+            .expect("UNIX timestamp should always be valid since it's controlled by the song sync")
+    })?;
+    info!("Last sync done at: {:?}", last_sync);
+
+    let songs_to_sync: Vec<MeiliSong> = songs::table
+        .filter(
+            songs::updated_at
+                .le(last_sync)
+                .or(extra_song_info::updated_at.le(last_sync)),
+        )
+        .left_join(extra_song_info::table)
+        .select((Song::as_select(), extra_song_info::all_columns.nullable()))
+        .load::<(Song, Option<ExtraSongInfo>)>(&mut conn)
+        .await?
+        .iter_mut()
+        .map(|x| {
+            let x = x.clone();
+            MeiliSong {
+                song: x.0,
+                extra_song_info: x.1,
+            }
+        })
+        .collect();
+
+    meili
+        .as_ref()
+        .unwrap()
+        .index("songs")
+        .add_documents(&songs_to_sync, Some("id"))
+        .await?;
+
+    let _: () = redis
+        .set(
+            "last_meilisearch_sync",
+            OffsetDateTime::now_utc().unix_timestamp(),
+            None,
+            None,
+            false,
+        )
+        .await?;
+
+    Ok(())
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,5 +1,6 @@
 pub mod errors;
 pub mod game_types;
+pub mod meilisearch;
 pub mod modifiers;
 pub mod musicbrainz;
 pub mod query;


### PR DESCRIPTION
I've decided on using Meilisearch for search. It's well-supported and easier to integrate into a frontend for example, with good SDKs and integrations readily available. Also, full text search on Postgres just isn't very good, requires messing with extensions, and might not really have fleshed out features you'd expect to have for a good search experience (typo tolerance for example). Obvious possible bias warning but the Meilisearch article puts it pretty well and I generally agree: https://www.meilisearch.com/blog/postgres-full-text-search-limitations

To sync Postgres and Meilisearch, I'll have the server periodically check if songs/extra_song_info are updated, using a timestamp indicating the time of update and time of last sync to be able to tell what needs syncing and what doesn't.

For easier initial setup, especially for local testing, I'm considering making Meilisearch optional.

The progress:
- [x] Meilisearch client is created and accessible from AppState
- [x] Meilisearch is optional
- [x] Automatic sync by schedule, syncing only updated entries
- [x] Sync song deletions
- [x] CLI commands to force sync
- [x] Sync user deletions
- [x] Make sync schedule configurable
- [x] Indicate if search is available in a status endpoint

I've also made the decision to not have dedicated API endpoints for search. Meilisearch recommends to just expose it directly and to just point clients at the instance, which allows for [easy integration into a frontend](https://www.meilisearch.com/docs/guides/front_end/front_end_integration) and compatibility with any other Meilisearch clients, of which there's ones available for a lot of languages, and even if there wasn't, the API is documented and just uses JSON over HTTP. Making another API to wrap Meilisearch's would just be reinventing the wheel for no noticeable benefit.